### PR TITLE
fix: resize logic when input matrix

### DIFF
--- a/src/Functions.cpp
+++ b/src/Functions.cpp
@@ -14,7 +14,7 @@ std::vector<std::vector<long long>> *getTable()
 
     std::vector<std::vector<long long>> *table = new std::vector<std::vector<long long>>(rows);
 
-    for (int i = 0; i < columns; i++)
+    for (int i = 0; i < rows; i++)
         (*table)[i].resize(columns);
 
     for (int r = 0; r < rows; r++)


### PR DESCRIPTION
Resize logic was incorrect, by iterating the matrix table by the columns and not by the rows.